### PR TITLE
Fixed build path residue in installed files with find

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -61,6 +61,8 @@ build() {
 
     # Build
     colcon build --merge-install ${COLCON_EXTRA_ARGS}
+    echo Fixing paths...
+    find . -type f -exec sed -i "s_${srcdir}/install_/opt/ros/humble_g" {} +
 }
 
 package() {


### PR DESCRIPTION
If someone knows how to do this with colcon args this would be better but I didn't get it to work trough trying several different arguments. So for now I simply `find` and replace the occurrences of the build dir path. This fixes #2.